### PR TITLE
Update to remove the "?useskin=vector" bit from the address bar after the page loads.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -73,7 +73,7 @@
       "js": [
         "updateAddress.js"
       ],
-      "run_at":"document_start"
+      "run_at":"document_end"
     }
   ]
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -47,7 +47,9 @@
     "service_worker": "worker.js"
   },
   "action": {
-    "default_icon": "icons/logo_32.png",
+    "default_icon": {
+      "32": "icons/logo_32.png"
+    },
     "default_title": "Old Wiki",
     "default_popup": "popup/popup.html"
   },
@@ -73,7 +75,7 @@
       "js": [
         "updateAddress.js"
       ],
-      "run_at":"document_end"
+      "run_at":"document_start"
     }
   ]
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -50,5 +50,30 @@
     "default_icon": "icons/logo_32.png",
     "default_title": "Old Wiki",
     "default_popup": "popup/popup.html"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.wikipedia.org/*",
+        "*://*.wiktionary.org/*",
+        "*://*.wikiquote.org/*",
+        "*://*.wikibooks.org/*",
+        "*://*.wikisource.org/*",
+        "*://species.wikimedia.org/*",
+        "*://*.wikinews.org/*",
+        "*://*.wikiversity.org/*",
+        "*://*.wikivoyage.org/*",
+        "*://commons.wikimedia.org/*",
+        "*://*.wikidata.org/*",
+        "*://*.mediawiki.org/*",
+        "*://meta.wikimedia.org/*",
+        "*://incubator.wikimedia.org/*",
+        "*://wikitech.wikimedia.org/*"
+      ],
+      "js": [
+        "updateAddress.js"
+      ],
+      "run_at":"document_start"
+    }
+  ]
 }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -23,6 +23,11 @@
     <input type="checkbox" id="vectorSkinActivationSwitch">
     <span class="slider round"></span>
   </label>
+  <label class="switch">
+    <div class="slider-text">Hide URL query</div>
+    <input type="checkbox" id="hideURLQuerySwitch">
+    <span class="slider round"></span>
+  </label>
 </section>
 
 <section id="footer">

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -4,15 +4,21 @@
 var browser = chrome;
 
 var vectorSkinActivation = true;
+var hideURLQuery = true;
 
 var vectorSkinActivationSwitch = document.getElementById("vectorSkinActivationSwitch");
+var hideURLQuerySwitch = document.getElementById("hideURLQuerySwitch");
 
 // load stored settings from local storage
 browser.storage.local.get((items) => {
 	vectorSkinActivation = items.hasOwnProperty('vector_skin_activation') ? items.vector_skin_activation : true;
+	hideURLQuery = items.hasOwnProperty('hide_url_query') ? items.hide_url_query : true;
 
 	vectorSkinActivationSwitch.checked = vectorSkinActivation;
+	hideURLQuerySwitch.checked = hideURLQuery;
+	
 	vectorSkinActivationSwitch.addEventListener("change", activationSwitchChanged);
+	hideURLQuerySwitch.addEventListener("change", activationSwitchChanged);
 });
 
 /**
@@ -21,7 +27,11 @@ browser.storage.local.get((items) => {
 function activationSwitchChanged() {
 	// apply skin or not
 	vectorSkinActivation = vectorSkinActivationSwitch.checked;
-	browser.storage.local.set({vector_skin_activation: vectorSkinActivationSwitch.checked});
+	hideURLQuery = hideURLQuerySwitch.checked;
+	browser.storage.local.set({
+		vector_skin_activation: vectorSkinActivationSwitch.checked,
+		hide_url_query: hideURLQuerySwitch.checked
+	});
 }
 
 /**

--- a/extension/updateAddress.js
+++ b/extension/updateAddress.js
@@ -1,13 +1,12 @@
-// updateAddress.js
-// by Torma
-// https://github.com/torma616
-//
-//
-// This updates the URL on the webpage after
-// the ?useskin=vector query has been applied,
-// to bring us back to the good old days when
-// Vector was default, as it should be.
-//
+/** updateAddress.js
+ * by Torma
+ * https://github.com/torma616
+ * 
+ * 
+ * This updates the URL on the webpage after the ?useskin=vector query has been applied,
+ * to bring us back to the good old days when Vector was default, as it should be. 
+ * 
+ **/ 
 'use strict';
 
 (async () => {

--- a/extension/updateAddress.js
+++ b/extension/updateAddress.js
@@ -1,0 +1,17 @@
+// updateAddress.js
+// by Torma
+// https://github.com/torma616
+//
+//
+// This updates the URL on the webpage after
+// the ?useskin=vector query has been applied,
+// to bring us back to the good old days when
+// Vector was default, as it should be.
+//
+if (document.location.search === '?useskin=vector') {
+  window.history.replaceState(
+    null, 
+    document.title, 
+    `${document.location.origin}${document.location.pathname}${document.location.hash}`
+    )
+}

--- a/extension/updateAddress.js
+++ b/extension/updateAddress.js
@@ -8,25 +8,69 @@
 // to bring us back to the good old days when
 // Vector was default, as it should be.
 //
+'use strict';
 
 (async () => {
   const browser = chrome;
-  const { hide_url_query: hideQuery } = await browser.storage.local.get('hide_url_query')
-  const { origin, pathname, hash } = window.location;
-  let { search } = window.location;
+  let hideQuery = true;
 
-  if (hideQuery) {
-    if (search.includes('useskin=vector')) {
-      search = search
-        .replace(/(\?|&)useskin=vector(&|$)/, '$1')
-        .replace(/&$/, '');
-      if (search === '?') {
-        search = '';
-      }
-      window.history.replaceState(
-        null,
-        document.title,
-        `${origin}${pathname}${search}${hash}`);
+  /**
+   * Called when the settings are loaded from the local storage.
+   * 
+   * @param {[key: string]: any} items The items from the local storage.
+   */
+  function onSettingsLoaded(items) {
+    parseSettings(items);
+    checkURL(hideQuery);
+  }
+
+  /**
+   * Parses the items from the local storage to the global variables in this worker script.
+   * 
+   * @param {[key: string]: any} items The items from the local storage.
+   */
+  function parseSettings(items) {
+    hideQuery = items.hasOwnProperty('hide_url_query') ? items.hide_url_query : true;
+  }
+
+  /**
+   * Processes the query string by removing the 'useskin=vector' parameter and updates the browser history.
+   * 
+   * @param {string} query The search string from the URL that needs to be processed.
+   */
+  function processQuery(query) {
+    let search = query.replace(/(\?|&)useskin=vector(&|$)/, '$1').replace(/&$/, '');
+    if (search === '?') {
+      search = '';
+    }
+    updateBrowserHistory(search)
+  }
+
+  /**
+   * Updates the browser history state with the new URL.
+   * 
+   * @param {string} search The updated search string part of the URL.
+   */
+  function updateBrowserHistory(search) {
+    const { origin, pathname, hash } = window.location;
+    window.history.replaceState(null, document.title, `${origin}${pathname}${search}${hash}`);
+  }
+
+  /**
+   * Checks the current URL's search string to determine if it contains the 'useskin=vector' parameter.
+   * If the parameter is present, it processes the query string to remove it.
+   * 
+   * @param {Boolean} isHidden Whether or not the query display is enabled via settings or not
+   */
+  function checkURL(isHidden) {
+    let { search } = window.location;
+    if (isHidden && search.includes('useskin=vector')) {
+      processQuery(search)
     }
   }
+
+  /**
+   * Loads the current settings from local storage and processes the URL if needed.
+   */
+  await browser.storage.local.get(onSettingsLoaded);
 })();

--- a/extension/updateAddress.js
+++ b/extension/updateAddress.js
@@ -8,10 +8,17 @@
 // to bring us back to the good old days when
 // Vector was default, as it should be.
 //
-if (document.location.search === '?useskin=vector') {
+
+let queryString = document.location.search;
+
+if (queryString.includes('useskin=vector')) {
+    queryString = queryString.replace(/(|&)useskin=vector(&|)/, '');
+    if (queryString === '?') {
+        queryString = '';
+    }
   window.history.replaceState(
     null, 
     document.title, 
-    `${document.location.origin}${document.location.pathname}${document.location.hash}`
+    `${document.location.origin}${document.location.pathname}${queryString}${document.location.hash}`
     )
 }

--- a/extension/updateAddress.js
+++ b/extension/updateAddress.js
@@ -9,16 +9,24 @@
 // Vector was default, as it should be.
 //
 
-let queryString = document.location.search;
+(async () => {
+  const browser = chrome;
+  const { hide_url_query: hideQuery } = await browser.storage.local.get('hide_url_query')
+  const { origin, pathname, hash } = window.location;
+  let { search } = window.location;
 
-if (queryString.includes('useskin=vector')) {
-    queryString = queryString.replace(/(|&)useskin=vector(&|)/, '');
-    if (queryString === '?') {
-        queryString = '';
+  if (hideQuery) {
+    if (search.includes('useskin=vector')) {
+      search = search
+        .replace(/(\?|&)useskin=vector(&|$)/, '$1')
+        .replace(/&$/, '');
+      if (search === '?') {
+        search = '';
+      }
+      window.history.replaceState(
+        null,
+        document.title,
+        `${origin}${pathname}${search}${hash}`);
     }
-  window.history.replaceState(
-    null, 
-    document.title, 
-    `${document.location.origin}${document.location.pathname}${queryString}${document.location.hash}`
-    )
-}
+  }
+})();

--- a/extension/worker.js
+++ b/extension/worker.js
@@ -4,6 +4,7 @@
 var browser = chrome;
 
 var vectorSkinActivation = true;
+var hideURLQuery = true;
 
 /**
  * Loads the current settings.
@@ -40,6 +41,7 @@ function onSettingsLoaded(items) {
  */
 function parseSettings(items) {
     vectorSkinActivation = items.hasOwnProperty('vector_skin_activation') ? items.vector_skin_activation : true;
+    hideURLQuery = items.hasOwnProperty('hide_url_query') ? items.hide_url_query : true;
 }
 
 /**
@@ -49,6 +51,7 @@ function parseSettings(items) {
  */
  function parseChangedSettings(items) {
     vectorSkinActivation = items.hasOwnProperty('vector_skin_activation') ? items.vector_skin_activation.newValue : true;
+    hideURLQuery = items.hasOwnProperty('hide_url_query') ? items.hide_url_query.newValue : true;
 }
 
 /**


### PR DESCRIPTION
This runs a content script at document_end that calls window.history.replaceState() in order to remove the `?useskin=vector` querystring from the URL.